### PR TITLE
Exclude tests from setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author_email= email,
     url='https://github.com/xesscorp/kinparse',
 #    packages=['kinparse',],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     entry_points={'console_scripts':['kinparse = kinparse.__main__:main']},
     package_dir={'kinparse':
                  'kinparse'},


### PR DESCRIPTION
Same as [skidl#38](https://github.com/xesscorp/skidl/pull/38). I've done these two because I wanted to use skidl and needed to package this as a dependency. You might want to go through your other python repos and do the same, I don't want to flood you with PRs.